### PR TITLE
Small changes to compile for Linux

### DIFF
--- a/RSBrokenMedia.jucer
+++ b/RSBrokenMedia.jucer
@@ -105,6 +105,27 @@
         <MODULEPATH id="juce_gui_extra" path="../../../../../../JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_audio_basics" path="../../juce"/>
+        <MODULEPATH id="juce_audio_devices" path="../../juce"/>
+        <MODULEPATH id="juce_audio_formats" path="../../juce"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="../../juce"/>
+        <MODULEPATH id="juce_audio_processors" path="../../juce"/>
+        <MODULEPATH id="juce_audio_utils" path="../../juce"/>
+        <MODULEPATH id="juce_core" path="../../juce"/>
+        <MODULEPATH id="juce_data_structures" path="../../juce"/>
+        <MODULEPATH id="juce_dsp" path="../../juce"/>
+        <MODULEPATH id="juce_events" path="../../juce"/>
+        <MODULEPATH id="juce_graphics" path="../../juce"/>
+        <MODULEPATH id="juce_gui_basics" path="../../juce"/>
+        <MODULEPATH id="juce_gui_extra" path="../../juce"/>
+      </MODULEPATHS>
+    </LINUX_MAKE>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>

--- a/Source/Utilities.h
+++ b/Source/Utilities.h
@@ -25,7 +25,7 @@ inline float scale(float input, float inLow, float inHi, float outLow, float out
 inline float wrap(float a, float b)
 {
     float mod = fmodf(a, b);
-    return (a >= 0 ? 0 : b) + (mod > __FLT_EPSILON__ || !isnan(mod) ? mod : 0);
+    return (a >= 0 ? 0 : b) + (mod > __FLT_EPSILON__ || !std::isnan(mod) ? mod : 0);
 }
 
 struct LofiProcessorParameters


### PR DESCRIPTION
In order to compile RSBrokenMedia for Linux, I had to make a small update in `Utilities.h` to make an explicit reference to `std::isnan`. In addition, I updated the jucer file to create a Makefile for Linux. Once I made these two adjustments, I was able to compile the plugin successfully, and so far it runs well in Kubuntu and Bitwig 5.1.2.